### PR TITLE
limits volume/mic scroll-up events to 115%

### DIFF
--- a/.config/waybar/config.jsonc
+++ b/.config/waybar/config.jsonc
@@ -110,7 +110,7 @@
     "tooltip": false,
     "format-muted": " Muted",
     "on-click": "wpctl set-mute @DEFAULT_SINK@ toggle",
-    "on-scroll-up": "wpctl set-volume @DEFAULT_SINK@ 10%+",
+    "on-scroll-up": "wpctl set-volume @DEFAULT_SINK@ 10%+ --limit 1.15",
     "on-scroll-down": "wpctl set-volume @DEFAULT_SINK@ 10%-",
     "format-icons": {
       "headphone": "",
@@ -131,7 +131,7 @@
     "format-source": " {volume}%",
     "format-source-muted": " Muted",
     "on-click": "wpctl set-mute @DEFAULT_SOURCE@ toggle",
-    "on-scroll-up": "wpctl set-volume @DEFAULT_SOURCE@ 5%+",
+    "on-scroll-up": "wpctl set-volume @DEFAULT_SOURCE@ 5%+ --limit 1.15",
     "on-scroll-down": "wpctl set-volume @DEFAULT_SOURCE@ 5%-",
   },
   "network": {


### PR DESCRIPTION
I'm using your waybar config (thanks! looks and works great) and added this for myself. I found it helpful so thought you might too.

Scroll up events happen very quickly for me and didn't seem to have any cap on sink %, so this allows going to 115% on scroll. 0% is already capped on the low end.

context on flag: https://gitlab.freedesktop.org/pipewire/wireplumber/-/merge_requests/413